### PR TITLE
Fix test_dispatcher.py::test_backtesting_scheduler.

### DIFF
--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -278,7 +278,8 @@ def test_backtesting_scheduler(schedule_dates, backtesting_dispatcher):
         backtesting_dispatcher.subscribe(src, proces_event)
 
         for schedule_date in schedule_dates:
-            schedule_date = schedule_date.replace(tzinfo=datetime.timezone.utc)
+            if dt.is_naive(schedule_date):
+                schedule_date = schedule_date.replace(tzinfo=datetime.timezone.utc)
             backtesting_dispatcher.schedule(schedule_date, scheduled_job_factory(schedule_date))
             backtesting_dispatcher.schedule(schedule_date, failing_scheduled_job)
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -249,6 +249,7 @@ def test_sniffers(backtesting_dispatcher):
         datetime.datetime(2000, 1, 2, 0, 0, 0),
         datetime.datetime(2001, 1, 2, 0, 0, 0),
         datetime.datetime(2002, 1, 1, 0, 0, 0),
+        dt.local_now(),
         dt.utc_now(),
     ],
 ])

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -249,7 +249,6 @@ def test_sniffers(backtesting_dispatcher):
         datetime.datetime(2000, 1, 2, 0, 0, 0),
         datetime.datetime(2001, 1, 2, 0, 0, 0),
         datetime.datetime(2002, 1, 1, 0, 0, 0),
-        dt.local_now(),
         dt.utc_now(),
     ],
 ])


### PR DESCRIPTION
If your local time zone is "faster" than UTC, the task scheduled at `df.local_now()` won't be executed.

For example, my local time zone is GMT+8,  after 
https://github.com/gbeced/basana/blob/c323ecd565bd05e33da4bacc72aa39b8ec300003/tests/test_dispatcher.py#L281
the `schedule_date` will become a datetime in the future, with which the task won't be executed by `BacktestingDispatcher._dispatch_loop`.